### PR TITLE
Get token from v1 API

### DIFF
--- a/paprika_recipes/remote.py
+++ b/paprika_recipes/remote.py
@@ -115,7 +115,7 @@ class Remote(RecipeManager):
             try:
                 result = self._request(
                     "post",
-                    "/api/v2/account/login/",
+                    "/api/v1/account/login/",
                     data={"email": self._email, "password": self._password},
                     authenticated=False,
                 )


### PR DESCRIPTION
Looks like some time last year, Paprika made a change on the API. See also the conversation here: https://gist.github.com/mattdsteele/7386ec363badfdeaad05a418b9a1f30a

You used to be able to get a token like this:
```
curl -X POST https://www.paprikaapp.com/api/v2/account/login -d 'email=you@example.com&password=supersecure123'
```

However, this now returns:
```
{"error":{"code":0,"message":"Unrecognized client."}}
```

However, you can still get a token by authenticating to the `v1` API and then taking that token. 

Updated the `bearer_token` call to request the token from v1 API.



